### PR TITLE
SimpleClient alternative client. Supports contexts, Call(), Ping()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .envrc
 coverage.html
 coverage.out
+demo

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ import (
 	"context"
 	"log/slog"
 	"os"
-	"time"
 
 	slogctx "github.com/veqryn/slog-context"
 	"github.com/wcn/gearman/v2"
@@ -31,19 +30,17 @@ import (
 
 func main() {
 	config := gearman.DefaultConfig("localhost:4730")
-	config.Timeout = 60 * time.Second
-	client, _ := gearman.NewSimpleClient(config)
+	client := gearman.NewSimpleClient(config)
 
-	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	ctx := slogctx.With(context.Background(), logger)
-	client.Start(ctx)
-	defer client.Close()
-
-	childCtx := slogctx.With(ctx, logger.With(slog.String("scope", "single-job")))
-	response, err := client.Call(childCtx, "reverse", []byte("hello world"))
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	ctx := slogctx.With(context.Background(), log)
+	err := client.Start(ctx)
 	if err != nil {
 		panic(err)
 	}
+	defer client.Close()
+
+	response, _ := client.Call(ctx, "reverse", []byte("hello world"))
 	println(string(response)) // !dlrow olleh
 }
 ```
@@ -53,19 +50,20 @@ func main() {
 ### func NewSimpleClient
 
 ```go
-func NewSimpleClient(config ClientConfig) (*SimpleClient, error)
+func NewSimpleClient(config ClientConfig) *SimpleClient
 ```
 
-NewSimpleClient returns a new Gearman client pointing at the configured server
+NewSimpleClient returns a new Gearman client pointing at the configured server.
+Note the client must be `Start()`ed before you use it.
 
 #### func (*SimpleClient) Start
 
 ```go
-func (c *SimpleClient) Start(context.Context ctx) error
+func (c *SimpleClient) Start(ctx context.Context) error
 ```
 
-Start() starts the packet-processing goroutines required for communication
-with gearmand
+Start() connects to gearmand and starts the packet-processing goroutines
+required to receive responses from it
 
 #### func (*SimpleClient) Close
 
@@ -76,19 +74,24 @@ func (c *SimpleClient) Close() error
 Close terminates the connection to the server and stops the packet-processing
 goroutines.
 
-#### func (*Client) Call
+#### func (*SimpleClient) Call
 
 ```go
-func (c *Client) Call(ctx context.Context, function string, payload []byte) ([]byte, error)
+func (c *SimpleClient) Call(ctx context.Context, function string, payload []byte) ([]byte, error)
 ```
 
 Call sends a new job to the server with the specified function and payload,
 waits for the job to complete and returns any response data.
 
-This library may log certain things via slog. It will
-use [slogctx](https://github.com/veqryn/slog-context) to get a slog instance
-from ctx where possible, but if you have not added a slog instance to your
-context using that library then slog.Default will be used instead.
+#### func (*SimpleClient) Ping
+
+```go
+func (c *SimpleClient) Ping(ctx context.Context) error
+```
+
+Ping uses gearmand's ECHO_REQ/ECHO_RES commands to check if the connection is
+working. Will honour the context's timeout/deadline, or use the `timeout`
+from the client's config if not.
 
 ## Logging
 
@@ -98,7 +101,9 @@ example if we receive an invalid packet from gearmand. This library therefore
 logs these events via slog. [slogctx](https://github.com/veqryn/slog-context) is
 used to obtain slog instances - you can pass your own slog in the contexts
 passed to `Start()` and `Call()`. The library will use the most-appropriately
-scoped logger it can.
+scoped logger it can. If it cannot get one from the context then
+slog.Default will be used instead (via slogctx's
+fallback behaviour)
 
 # HISTORY
 

--- a/client.go
+++ b/client.go
@@ -27,14 +27,17 @@ package gearman
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"os"
 	"strings"
 	"sync"
 	"time"
 
+	slogctx "github.com/veqryn/slog-context"
 	"github.com/wcn/gearman/v2/job"
 	"github.com/wcn/gearman/v2/packet"
 	"github.com/wcn/gearman/v2/scanner"
@@ -67,7 +70,7 @@ type partialJob struct {
 // to the appropriate jobs.
 type Client struct {
 	// conn is the connection to the gearman server
-	conn io.WriteCloser
+	conn net.Conn
 	// packets is the stream of incoming gearman packets from the server
 	packets chan *packet.Packet
 	// jobs is a router for sending packets to the correct job to interpret
@@ -80,18 +83,53 @@ type Client struct {
 	connLock sync.RWMutex
 	connErr  error // tracks the last connection error
 	closed   bool  // tracks if the client has been closed
+	// goroutine management (added in v2, backward compatible)
+	started bool // prevents multiple Start() calls
+	ctx     context.Context
+	cancel  context.CancelFunc
+}
+
+// Start begins the background goroutines for packet processing.
+// When the provided context is cancelled, the client will automatically close,
+func (c *Client) Start(ctx context.Context) {
+	c.connLock.Lock()
+	defer c.connLock.Unlock()
+
+	if c.started {
+		return
+	}
+
+	c.ctx, c.cancel = context.WithCancel(ctx)
+	c.started = true
+
+	go c.read(c.ctx, scanner.New(c.conn))
+	go c.routePackets(c.ctx)
+
+	// Monitor context cancellation and auto-close
+	go func() {
+		<-ctx.Done()
+		c.Close()
+	}()
 }
 
 // Close terminates the connection to the server and cleans up resources.
 func (c *Client) Close() error {
 	c.connLock.Lock()
+	defer c.connLock.Unlock()
+
+	if c.closed {
+		return nil
+	}
+
 	c.closed = true
-	c.connLock.Unlock()
+	if c.cancel != nil {
+		c.cancel()
+	}
 	// TODO: figure out when to close packet chan
 	return c.conn.Close()
 }
 
-func (c *Client) submit(fn string, payload []byte, data, warnings io.WriteCloser, t packet.Type) (*job.Job, error) {
+func (c *Client) submit(fn string, payload []byte, data, warnings io.WriteCloser, t packet.Type, timeout time.Duration) (*job.Job, error) {
 	// Check if the client has been closed or has a connection error
 	c.connLock.RLock()
 	if c.closed {
@@ -128,28 +166,34 @@ func (c *Client) submit(fn string, payload []byte, data, warnings io.WriteCloser
 	select {
 	case c.partialJobs <- &partialJob{data: data, warnings: warnings}:
 		// Job submitted successfully
-	case <-time.After(30 * time.Second):
+	case <-time.After(timeout):
 		return nil, fmt.Errorf("timeout waiting for job confirmation")
 	}
 
 	select {
 	case j := <-c.newJobs:
 		return j, nil
-	case <-time.After(30 * time.Second):
+	case <-time.After(timeout):
 		return nil, fmt.Errorf("timeout waiting for job creation")
 	}
+}
+
+// SubmitWithTimeout sends a new job to the server with the specified function and payload and timeout.
+// You must provide two WriteClosers for data and warnings to be written to.
+func (c *Client) SubmitWithTimeout(fn string, payload []byte, data, warnings io.WriteCloser, timeout time.Duration) (*job.Job, error) {
+	return c.submit(fn, payload, data, warnings, packet.SubmitJob, timeout)
 }
 
 // Submit sends a new job to the server with the specified function and payload. You must provide
 // two WriteClosers for data and warnings to be written to.
 func (c *Client) Submit(fn string, payload []byte, data, warnings io.WriteCloser) (*job.Job, error) {
-	return c.submit(fn, payload, data, warnings, packet.SubmitJob)
+	return c.submit(fn, payload, data, warnings, packet.SubmitJob, 30*time.Second)
 }
 
 // SubmitBackground submits a background job. There is no access to data, warnings, or completion
 // state.
 func (c *Client) SubmitBackground(fn string, payload []byte) error {
-	_, err := c.submit(fn, payload, discard, discard, packet.SubmitJobBg)
+	_, err := c.submit(fn, payload, discard, discard, packet.SubmitJobBg, 30*time.Second)
 	return err
 }
 
@@ -176,17 +220,26 @@ func (c *Client) deleteJob(handle string) {
 
 // read attempts to read incoming packets from the gearman server to route them to the job
 // they are intended for.
-func (c *Client) read(scanner *bufio.Scanner) {
+func (c *Client) read(ctx context.Context, scanner *bufio.Scanner) {
+	logger := slogctx.FromCtx(ctx)
+
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Fprintf(os.Stderr, "GEARMAN PANIC: recovered from panic in read loop: %v\n", r)
+			logger.Error("Gearman client panic recovered in read loop", slog.Any("panic", r))
 		}
 	}()
 
 	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			logger.Debug("Read loop cancelled")
+			return
+		default:
+		}
+
 		pack := &packet.Packet{}
 		if err := pack.UnmarshalBinary(scanner.Bytes()); err != nil {
-			fmt.Fprintf(os.Stderr, "GEARMAN WARNING: error parsing packet! %v\n", err)
+			logger.Warn("Error parsing packet", slog.Any("error", err))
 			continue // Skip this packet and continue reading
 		}
 
@@ -194,32 +247,38 @@ func (c *Client) read(scanner *bufio.Scanner) {
 		select {
 		case c.packets <- pack:
 			// Packet sent successfully
+		case <-ctx.Done():
+			logger.Debug("Read loop cancelled while sending packet")
+			return
 		default:
-			fmt.Fprintf(os.Stderr, "GEARMAN WARNING: packet channel full, dropping packet\n")
+			logger.Warn("Packet channel full, dropping packet")
 		}
 	}
 	if scanner.Err() != nil {
 		errMsg := scanner.Err().Error()
 		if strings.Contains(errMsg, "use of closed network connection") {
-			// fmt.Fprintf(os.Stderr, "DEBUG: Connection closed normally\n")
+			logger.Debug("Connection closed normally")
 		} else {
-			fmt.Fprintf(os.Stderr, "GEARMAN WARNING: error scanning! %v\n", scanner.Err())
+			logger.Warn("Error scanning packets", slog.Any("error", scanner.Err()))
 			// Mark connection as failed
 			c.connLock.Lock()
 			c.connErr = scanner.Err()
 			c.connLock.Unlock()
-			c.failPendingJobs(scanner.Err())
+			c.failPendingJobs(ctx, scanner.Err())
 		}
 	}
 }
 
 // failPendingJobs fails all pending jobs when a scanner error occurs
-func (c *Client) failPendingJobs(err error) {
+func (c *Client) failPendingJobs(ctx context.Context, err error) {
+	logger := slogctx.FromCtx(ctx)
 	c.jobLock.Lock()
 	defer c.jobLock.Unlock()
 
 	for handle, packets := range c.jobs {
-		fmt.Fprintf(os.Stderr, "GEARMAN WARNING: failing job %s due to scanner error: %v\n", handle, err)
+		logger.Warn("Failing job due to scanner error",
+			slog.String("handle", handle),
+			slog.Any("error", err))
 		failPacket := &packet.Packet{
 			Type:      packet.WorkFail,
 			Arguments: [][]byte{[]byte(handle)},
@@ -228,68 +287,88 @@ func (c *Client) failPendingJobs(err error) {
 		select {
 		case packets <- failPacket:
 		default:
-			fmt.Fprintf(os.Stderr, "GEARMAN WARNING: could not send fail packet to job %s\n", handle)
+			logger.Warn("Could not send fail packet to job", slog.String("handle", handle))
 		}
 	}
 }
 
 // routePackets forwards incoming packets to the correct job.
-func (c *Client) routePackets() {
+func (c *Client) routePackets(ctx context.Context) {
+	logger := slogctx.FromCtx(ctx)
+
 	// operate on every packet that has been read
-	for pack := range c.packets {
-		if len(pack.Arguments) == 0 {
-			fmt.Fprintln(os.Stderr, "GEARMAN WARNING: packet read with no handle!")
-			continue
-		}
-
-		handle := string(pack.Arguments[0])
-		switch pack.Type {
-		case packet.JobCreated:
-			// create a new channel to send packets for this job
-			packets := make(chan *packet.Packet)
-			// optimistically hope that the last job submitted is the same one that just started
-			pj := <-c.partialJobs
-			// hook up the job to its packet stream
-			j := job.New(handle, pj.data, pj.warnings, packets)
-			// add the packet stream to the internal routing map
-			c.addJob(handle, packets)
-			// finally unblock the Submit() fn call
-			c.newJobs <- j
-
-			go func() {
-				defer close(packets)
-				defer c.deleteJob(handle)
-				j.Run()
-			}()
-		default:
-			// send the packet to the right job
-			pktStream := c.getJob(handle)
-			if pktStream != nil {
-				pktStream <- pack
-			} else {
-				fmt.Fprintf(os.Stderr, "GEARMAN WARNING: packet read with handle of '%s', "+
-					"no reference found in client.!\n", handle)
+	for {
+		select {
+		case pack := <-c.packets:
+			if len(pack.Arguments) == 0 {
+				logger.Warn("Packet read with no handle")
+				continue
 			}
+
+			handle := string(pack.Arguments[0])
+			switch pack.Type {
+			case packet.JobCreated:
+				// create a new channel to send packets for this job
+				packets := make(chan *packet.Packet)
+				// optimistically hope that the last job submitted is the same one that just started
+				pj := <-c.partialJobs
+				// hook up the job to its packet stream
+				j := job.NewWithContext(ctx, handle, pj.data, pj.warnings, packets)
+				// add the packet stream to the internal routing map
+				c.addJob(handle, packets)
+				// finally unblock the Submit() fn call
+				c.newJobs <- j
+
+				go func() {
+					defer close(packets)
+					defer c.deleteJob(handle)
+					j.Run()
+				}()
+			default:
+				// send the packet to the right job
+				pktStream := c.getJob(handle)
+				if pktStream != nil {
+					pktStream <- pack
+				} else {
+					logger.Warn("Packet read with unknown handle", slog.String("handle", handle))
+				}
+			}
+		case <-ctx.Done():
+			logger.Debug("Route packets loop cancelled")
+			return
 		}
 	}
 }
 
-// NewClient returns a new Gearman client pointing at the specified server
-func NewClient(network, addr string) (*Client, error) {
+// newClientWithoutStart creates a client but doesn't start background goroutines.
+// This is used internally by SimpleClient.
+func newClientWithoutStart(network, addr string) (*Client, error) {
 	conn, err := net.Dial(network, addr)
 	if err != nil {
 		return nil, fmt.Errorf("error while establishing a connection to gearman: %s", err)
 	}
 
-	c := &Client{
+	return &Client{
 		conn:        conn,
 		packets:     make(chan *packet.Packet),
 		newJobs:     make(chan *job.Job),
 		partialJobs: make(chan *partialJob),
 		jobs:        make(map[string]chan *packet.Packet),
+	}, nil
+}
+
+// NewClient returns a new Gearman client pointing at the specified server.
+// For v2 compatibility, this automatically starts the background goroutines.
+func NewClient(network, addr string) (*Client, error) {
+	c, err := newClientWithoutStart(network, addr)
+	if err != nil {
+		return nil, err
 	}
-	go c.read(scanner.New(conn))
-	go c.routePackets()
+
+	// Auto-start with background context for v2 compatibility
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	ctx := slogctx.With(context.Background(), logger)
+	c.Start(ctx)
 
 	return c, nil
 }

--- a/client.go
+++ b/client.go
@@ -244,15 +244,14 @@ func (c *Client) deleteJob(handle string) {
 }
 
 // pingCounter is used to ensure uniqueness when multiple pings happen in the same nanosecond
-var pingCounter int64
+var pingCounter atomic.Uint64
 
 // generatePingToken creates a unique token for ping requests with "echo" prefix
 // Uses PID + timestamp + counter to ensure uniqueness without error handling
 func generatePingToken() string {
 	pid := os.Getpid()
 	now := time.Now().UnixNano()
-	counter := atomic.AddInt64(&pingCounter, 1)
-	return fmt.Sprintf("echo%d_%d_%d", pid, now, counter)
+	return fmt.Sprintf("echo%d_%d_%d", pid, now, pingCounter.Add(1))
 }
 
 // Ping sends an ECHO_REQ packet to the server and waits for the corresponding ECHO_RES.

--- a/client_test.go
+++ b/client_test.go
@@ -51,6 +51,8 @@ func mockClient() *Client {
 		newJobs:     make(chan *job.Job, 10),
 		jobs:        make(map[string]chan *packet.Packet, 10),
 		partialJobs: make(chan *partialJob, 10),
+		pings:       make(map[string]chan struct{}),
+		started:     true, // Default to started for most tests
 	}
 	go c.routePackets(context.Background())
 	return c
@@ -58,6 +60,7 @@ func mockClient() *Client {
 
 func TestSubmit(t *testing.T) {
 	c := mockClient()
+
 	buf := c.conn.(*bufferCloser)
 	expected := job.New("the_handle", nil, nil, make(chan *packet.Packet))
 	c.newJobs <- expected

--- a/client_test.go
+++ b/client_test.go
@@ -2,8 +2,11 @@ package gearman
 
 import (
 	"bytes"
+	"context"
+	"net"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/wcn/gearman/v2/job"
 	"github.com/wcn/gearman/v2/packet"
@@ -19,6 +22,27 @@ func (buf *bufferCloser) Close() error {
 	return nil
 }
 
+// Implement net.Conn interface
+func (buf *bufferCloser) LocalAddr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
+}
+
+func (buf *bufferCloser) RemoteAddr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 4730}
+}
+
+func (buf *bufferCloser) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (buf *bufferCloser) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (buf *bufferCloser) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
 func mockClient() *Client {
 	c := &Client{
 		conn:    &bufferCloser{},
@@ -28,7 +52,7 @@ func mockClient() *Client {
 		jobs:        make(map[string]chan *packet.Packet, 10),
 		partialJobs: make(chan *partialJob, 10),
 	}
-	go c.routePackets()
+	go c.routePackets(context.Background())
 	return c
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -45,6 +45,8 @@ func (buf *bufferCloser) SetWriteDeadline(t time.Time) error {
 
 func mockClient() *Client {
 	c := &Client{
+		//network: "tcp4",
+		//address: "localhost:4730",
 		conn:    &bufferCloser{},
 		packets: make(chan *packet.Packet),
 		// Add buffers to prevent blocking in test cases

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,17 @@
 module github.com/wcn/gearman/v2
 
-go 1.18
+go 1.21
 
-require github.com/stretchr/testify v1.10.0
+toolchain go1.24.5
+
+require (
+	github.com/stretchr/testify v1.10.0
+	github.com/veqryn/slog-context v0.8.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,13 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
+github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/veqryn/slog-context v0.8.0 h1:lDhwAgjwx52K5StqqQzi5d0Y/F4SNyGZbsXGd8MtucM=
+github.com/veqryn/slog-context v0.8.0/go.mod h1:8rsT72p0kzzN9lmkwtabIhxg7ZkpnKblt9x3Eix8Tc0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/packet/types.go
+++ b/packet/types.go
@@ -20,6 +20,10 @@ const (
 	WorkComplete = 13
 	// WorkFail = WORK_FAIL
 	WorkFail = 14
+	// EchoReq = ECHO_REQ
+	EchoReq = 16
+	// EchoRes = ECHO_RES
+	EchoRes = 17
 	// SubmitJobBg = SUBMIT_JOB_BG
 	SubmitJobBg = 18
 	// WorkData = WORK_DATA
@@ -45,6 +49,10 @@ func (t Type) String() string {
 		return "WorkComplete"
 	case WorkFail:
 		return "WorkFail"
+	case EchoReq:
+		return "EchoReq"
+	case EchoRes:
+		return "EchoRes"
 	case SubmitJobBg:
 		return "SubmitJobBg"
 	case WorkData:

--- a/ping_test.go
+++ b/ping_test.go
@@ -1,0 +1,185 @@
+package gearman
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wcn/gearman/v2/packet"
+)
+
+func TestClientPing(t *testing.T) {
+	c := mockClient()
+
+	ctx := context.Background()
+
+	// Test ping in a goroutine since it will block waiting for response
+	var pingErr error
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		pingErr = c.Ping(ctx)
+	}()
+
+	// Give the ping request time to be registered
+	time.Sleep(10 * time.Millisecond)
+
+	c.pingLock.RLock()
+	assert.Equal(t, 1, len(c.pings), "Expected one ping request to be registered")
+
+	var token string
+	for token = range c.pings {
+		break
+	}
+	c.pingLock.RUnlock()
+
+	// Simulate ECHO_RES response
+	c.packets <- &packet.Packet{
+		Type:      packet.EchoRes,
+		Arguments: [][]byte{[]byte(token)},
+	}
+
+	wg.Wait()
+	assert.NoError(t, pingErr, "Ping should succeed")
+
+	c.pingLock.RLock()
+	assert.Equal(t, 0, len(c.pings), "Ping request should be cleaned up after response")
+	c.pingLock.RUnlock()
+}
+
+func TestClientPingTimeout(t *testing.T) {
+	c := mockClient()
+
+	// very short timeout + we don't send response packets = expected timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+
+	err := c.Ping(ctx)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "context deadline exceeded", "Should be a timeout error")
+
+	c.pingLock.RLock()
+	assert.Equal(t, 0, len(c.pings), "Ping request should be cleaned up after timeout")
+	c.pingLock.RUnlock()
+}
+
+func TestClientPingSimple(t *testing.T) {
+	c := mockClient()
+
+	var pingErr error
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		pingErr = c.Ping(context.Background())
+	}()
+
+	// Give the ping request time to be registered
+	time.Sleep(10 * time.Millisecond)
+
+	c.pingLock.RLock()
+	assert.Equal(t, 1, len(c.pings), "Expected one ping request to be registered")
+
+	// determine the token used in ECHO_REQ so we can generate an ECHO_RES
+	// that will be routed back to the caller
+	var token string
+	for token = range c.pings {
+		break
+	}
+	c.pingLock.RUnlock()
+
+	c.packets <- &packet.Packet{
+		Type:      packet.EchoRes,
+		Arguments: [][]byte{[]byte(token)},
+	}
+
+	wg.Wait()
+	assert.NoError(t, pingErr, "Ping should succeed")
+}
+
+func TestSimpleClientPing(t *testing.T) {
+	sc := mockSimpleClient()
+
+	var pingErr error
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		pingErr = sc.Ping(context.Background())
+	}()
+
+	// Give the ping request time to be registered
+	time.Sleep(10 * time.Millisecond)
+
+	sc.client.pingLock.RLock()
+	assert.Equal(t, 1, len(sc.client.pings), "Expected one ping request to be registered")
+
+	var token string
+	for token = range sc.client.pings {
+		break
+	}
+	sc.client.pingLock.RUnlock()
+
+	// Simulate ECHO_RES response
+	sc.client.packets <- &packet.Packet{
+		Type:      packet.EchoRes,
+		Arguments: [][]byte{[]byte(token)},
+	}
+
+	wg.Wait()
+	assert.NoError(t, pingErr, "SimpleClient.Ping should succeed")
+
+	sc.client.pingLock.RLock()
+	assert.Equal(t, 0, len(sc.client.pings), "Ping request should be cleaned up after response")
+	sc.client.pingLock.RUnlock()
+}
+
+func TestSimpleClientPingStateValidation(t *testing.T) {
+	tests := []struct {
+		name          string
+		setup         func(*SimpleClient)
+		expectedError string
+	}{
+		{
+			name: "client not started",
+			setup: func(sc *SimpleClient) {
+				client := mockClient()
+				client.connLock.Lock()
+				client.started = false
+				client.connLock.Unlock()
+				sc.client = client
+			},
+			expectedError: "client has not been started - call Start(ctx) first",
+		},
+		{
+			name: "client closed",
+			setup: func(sc *SimpleClient) {
+				client := mockClient()
+				client.Close()
+				sc.client = client
+			},
+			expectedError: "client has been closed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := &SimpleClient{
+				config: DefaultConfig("localhost:4730"),
+			}
+			tt.setup(sc)
+
+			err := sc.Ping(context.Background())
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedError)
+		})
+	}
+}

--- a/ping_test.go
+++ b/ping_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/wcn/gearman/v2/packet"
 )
 
@@ -44,7 +45,7 @@ func TestClientPing(t *testing.T) {
 	}
 
 	wg.Wait()
-	assert.NoError(t, pingErr, "Ping should succeed")
+	require.NoError(t, pingErr, "Ping should succeed")
 
 	c.pingLock.RLock()
 	assert.Equal(t, 0, len(c.pings), "Ping request should be cleaned up after response")
@@ -60,7 +61,7 @@ func TestClientPingTimeout(t *testing.T) {
 
 	err := c.Ping(ctx)
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "context deadline exceeded", "Should be a timeout error")
 
 	c.pingLock.RLock()
@@ -134,7 +135,7 @@ func TestSimpleClientPing(t *testing.T) {
 	}
 
 	wg.Wait()
-	assert.NoError(t, pingErr, "SimpleClient.Ping should succeed")
+	require.NoError(t, pingErr, "SimpleClient.Ping should succeed")
 
 	sc.client.pingLock.RLock()
 	assert.Equal(t, 0, len(sc.client.pings), "Ping request should be cleaned up after response")
@@ -165,7 +166,7 @@ func TestSimpleClientPingStateValidation(t *testing.T) {
 				client.Close()
 				sc.client = client
 			},
-			expectedError: "client has been closed",
+			expectedError: "client is closed",
 		},
 	}
 
@@ -178,7 +179,7 @@ func TestSimpleClientPingStateValidation(t *testing.T) {
 
 			err := sc.Ping(context.Background())
 
-			assert.Error(t, err)
+			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.expectedError)
 		})
 	}

--- a/simple_client.go
+++ b/simple_client.go
@@ -1,0 +1,124 @@
+// Package gearman provides a simple, context-aware Gearman client implementation.
+package gearman
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"time"
+
+	slogctx "github.com/veqryn/slog-context"
+	"github.com/wcn/gearman/v2/job"
+)
+
+// SimpleClient provides a simplified, context-aware Gearman client interface.
+type SimpleClient struct {
+	client *Client // Wraps the original client
+	config ClientConfig
+}
+
+// ClientConfig holds configuration for the simple client.
+type ClientConfig struct {
+	Network string
+	Address string
+	Timeout time.Duration
+}
+
+// DefaultConfig returns a sensible default configuration.
+func DefaultConfig(address string) ClientConfig {
+	return ClientConfig{
+		Network: "tcp4",
+		Address: address,
+		Timeout: 60 * time.Second,
+	}
+}
+
+// NewSimpleClient creates a new simple Gearman client.
+// The client is created but background goroutines are not started.
+// You must call Start(ctx) before using the client in order to open the
+// connection to gearmand. client.Close() should be called to close the
+// connection unless you expect to make subsequent calls.
+func NewSimpleClient(config ClientConfig) (*SimpleClient, error) {
+	client, err := newClientWithoutStart(config.Network, config.Address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gearman client: %w", err)
+	}
+
+	return &SimpleClient{
+		client: client,
+		config: config,
+	}, nil
+}
+
+// Call performs a synchronous RPC call to the specified Gearman function.
+func (c *SimpleClient) Call(ctx context.Context, function string, payload []byte) ([]byte, error) {
+	logger := slogctx.FromCtx(ctx)
+
+	// Ensure client is connected
+	c.client.connLock.RLock()
+	if !c.client.started {
+		c.client.connLock.RUnlock()
+		return nil, fmt.Errorf("client has not been started - call Start(ctx) first")
+	}
+	if c.client.closed {
+		c.client.connLock.RUnlock()
+		return nil, fmt.Errorf("client has been closed")
+	}
+	c.client.connLock.RUnlock()
+
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline && c.config.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.config.Timeout)
+		defer cancel()
+	}
+
+	dataBuffer := &bytes.Buffer{}
+	warningsBuffer := &bytes.Buffer{}
+	dataCloser := &bufferWriteCloser{dataBuffer}
+	warningsCloser := &bufferWriteCloser{warningsBuffer}
+
+	gearmanJob, err := c.client.SubmitWithTimeout(function, payload, dataCloser, warningsCloser, c.config.Timeout)
+	if err != nil {
+		return nil, fmt.Errorf("gearman cannot submit job: %w", err)
+	}
+
+	done := make(chan job.State, 1)
+	go func() {
+		done <- gearmanJob.Run()
+	}()
+
+	select {
+	case state := <-done:
+		switch state {
+		case job.Completed:
+			return dataBuffer.Bytes(), nil
+		case job.Failed:
+			return nil, fmt.Errorf("gearman job failed")
+		default:
+			return nil, fmt.Errorf("gearman job finished with unexpected state: %v", state)
+		}
+	case <-ctx.Done():
+		logger.Debug("gearman Call() cancelled due to context")
+		return nil, ctx.Err()
+	}
+}
+
+// bufferWriteCloser wraps a bytes.Buffer to implement io.WriteCloser
+type bufferWriteCloser struct {
+	*bytes.Buffer
+}
+
+func (b *bufferWriteCloser) Close() error {
+	return nil
+}
+
+// Start begins the background goroutines for packet processing.
+// This must be called before using the client for any operations.
+func (c *SimpleClient) Start(ctx context.Context) {
+	c.client.Start(ctx)
+}
+
+// Close closes the client connection and cleanly shuts down all background processing.
+func (c *SimpleClient) Close() error {
+	return c.client.Close()
+}

--- a/simple_client_test.go
+++ b/simple_client_test.go
@@ -1,0 +1,192 @@
+package gearman
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockSimpleClient creates a SimpleClient with a mocked underlying Client
+func mockSimpleClient() *SimpleClient {
+	client := mockClient()
+	// Mark as started to pass state validation
+	client.connLock.Lock()
+	client.started = true
+	client.connLock.Unlock()
+
+	return &SimpleClient{
+		client: client,
+		config: ClientConfig{
+			Network: "tcp4",
+			Address: "test:4730",
+			Timeout: 100 * time.Millisecond, // Short timeout for tests
+		},
+	}
+}
+
+func TestSimpleClient_StateValidation(t *testing.T) {
+	tests := []struct {
+		name          string
+		setup         func(*SimpleClient)
+		expectedError string
+	}{
+		{
+			name: "client not started",
+			setup: func(sc *SimpleClient) {
+				// Create a client that hasn't been started
+				client := mockClient()
+				sc.client = client
+			},
+			expectedError: "client has not been started - call Start(ctx) first",
+		},
+		{
+			name: "client closed",
+			setup: func(sc *SimpleClient) {
+				// Create a client and close it
+				client := mockClient()
+				client.connLock.Lock()
+				client.started = true
+				client.connLock.Unlock()
+				client.Close()
+				sc.client = client
+			},
+			expectedError: "client has been closed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := &SimpleClient{
+				config: DefaultConfig("localhost:4730"),
+			}
+			tt.setup(sc)
+
+			result, err := sc.Call(context.Background(), "test", []byte("data"))
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedError)
+			assert.Nil(t, result)
+		})
+	}
+}
+
+func TestSimpleClient_Start(t *testing.T) {
+	sc := mockSimpleClient()
+	ctx := context.Background()
+
+	sc.Start(ctx)
+
+	// Verify client is marked as started
+	assert.True(t, sc.client.started)
+}
+
+func TestSimpleClient_Close(t *testing.T) {
+	tests := []struct {
+		name          string
+		setup         func(*SimpleClient)
+		expectedError bool
+	}{
+		{
+			name:  "close normally",
+			setup: func(sc *SimpleClient) {},
+		},
+		{
+			name:  "close multiple times",
+			setup: func(sc *SimpleClient) { sc.client.Close() },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := mockSimpleClient()
+			tt.setup(sc)
+
+			err := sc.Close()
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Verify client is marked as closed
+			assert.True(t, sc.client.closed)
+		})
+	}
+}
+
+func TestSimpleClient_CloseIdempotent(t *testing.T) {
+	sc := mockSimpleClient()
+
+	// First close
+	err1 := sc.Close()
+	assert.NoError(t, err1)
+
+	// Second close should also succeed (idempotent)
+	err2 := sc.Close()
+	assert.NoError(t, err2)
+
+	// Third close should also succeed
+	err3 := sc.Close()
+	assert.NoError(t, err3)
+}
+
+func TestDefaultConfig(t *testing.T) {
+	config := DefaultConfig("localhost:4730")
+
+	assert.Equal(t, "tcp4", config.Network)
+	assert.Equal(t, "localhost:4730", config.Address)
+	assert.Equal(t, 60*time.Second, config.Timeout)
+}
+
+func TestNewSimpleClient(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        ClientConfig
+		expectedError bool
+	}{
+		{
+			name: "invalid address",
+			config: ClientConfig{
+				Network: "tcp4",
+				Address: "invalid:address:port:too:many:parts",
+				Timeout: 30 * time.Second,
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewSimpleClient(tt.config)
+
+			if tt.expectedError {
+				require.Error(t, err)
+				assert.Nil(t, client)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, client)
+				assert.Equal(t, tt.config, client.config)
+				assert.NotNil(t, client.client)
+			}
+		})
+	}
+}
+
+func TestBufferWriteCloser(t *testing.T) {
+	buf := &bytes.Buffer{}
+	bwc := &bufferWriteCloser{buf}
+
+	// Test Write
+	n, err := bwc.Write([]byte("test data"))
+	assert.NoError(t, err)
+	assert.Equal(t, 9, n)
+	assert.Equal(t, "test data", buf.String())
+
+	// Test Close
+	err = bwc.Close()
+	assert.NoError(t, err)
+}

--- a/simple_client_test.go
+++ b/simple_client_test.go
@@ -39,6 +39,7 @@ func TestSimpleClient_StateValidation(t *testing.T) {
 			setup: func(sc *SimpleClient) {
 				// Create a client that hasn't been started
 				client := mockClient()
+				client.started = false // Override default for this test
 				sc.client = client
 			},
 			expectedError: "client has not been started - call Start(ctx) first",


### PR DESCRIPTION
In order to maintain v2 compatibility, Client still exists and works as before. However there's now a SimpleClient that supports various improvements:

 * context support: set a timeout, or cancel your context to shut down the connection cleanly.
 * Logging control: Sometimes the library needs to log outside of a request/response situation, where it cannot simply return an error. We support use of [slogctx](https://github.com/veqryn/slog-context) in your contexts, or use slog.Default if not. Using Client will result in logs to stderr as before.
 * Call() interface: you no longer have to futz around with writeClosers, just let the library wait until the call is complete and access the result as a byte slice.
 * Ping() interface: check your gearmand connection is working.
 * Separate instantiation from connection. NewSimpleClient does not return an error or connect: use the `Start()` method to connect and start the packet receiving goroutines.